### PR TITLE
Refactor test logic to remove injection points in `configure-develocity.gradle`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,7 @@ jobs:
 
       - name: Run demo project
         working-directory: demo-project
-        run: |
-          ./gradlew -I ../reference/configure-develocity.gradle \
-          -Ddevelocity.url=https://ge.solutions-team.gradle.com/ \
-          -Ddevelocity.injection-enabled=true \
-          -Ddevelocity.plugin.version=3.17.2
+        run: ./run.sh
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_ACCESS_KEY }}
 

--- a/demo-project/run.sh
+++ b/demo-project/run.sh
@@ -4,7 +4,13 @@ cd .. && ./gradlew clean publishAllPublicationsToLocalRepository
 
 cd demo-project
 
-./gradlew -I ../reference/configure-develocity.gradle \
+mkdir -p build
+rm build/configure-develocity.gradle
+echo 'initscript { repositories { maven { url = "../build/local-repo" } } }' >> build/configure-develocity.gradle
+echo '' >> build/configure-develocity.gradle
+cat ../reference/configure-develocity.gradle >> build/configure-develocity.gradle
+
+./gradlew -I build/configure-develocity.gradle \
     -Ddevelocity.url=https://ge.solutions-team.gradle.com/ \
     -Ddevelocity.injection-enabled=true \
     -Ddevelocity.plugin.version=3.17.2 \

--- a/plugin/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/plugin/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -121,6 +121,14 @@ class BaseInitScriptTest extends Specification {
         targetInitScriptsDir.mkdirs()
         File targetInitScript = new File(targetInitScriptsDir, initScript.name)
         Files.copy(initScript.toPath(), targetInitScript.toPath())
+        targetInitScript.text = """initscript {
+    repositories {
+        maven {
+            url "${System.getProperty('local.repo')}"
+        }
+    }
+}
+        """ + targetInitScript.text
 
         settingsFile << "rootProject.name = '${ROOT_PROJECT_NAME}'\n"
         buildFile << ''
@@ -210,7 +218,7 @@ task expectFailure {
         File initScriptsDir = new File(testProjectDir, "initScripts")
 
         envVars.put("DEVELOCITY_TEST_PLUGIN_REPOSITORY", System.getProperty('local.repo'))
-        envVars.put("DEVELOCITY_TEST_PLUGIN_VERSION", System.getProperty('pluginVersion'))
+        envVars.put("DEVELOCITY_INJECTION_PLUGIN_VERSION", System.getProperty('pluginVersion'))
         args << '-I' << new File(initScriptsDir, initScript).absolutePath
 
         def runner = ((DefaultGradleRunner) GradleRunner.create())

--- a/reference/configure-develocity.gradle
+++ b/reference/configure-develocity.gradle
@@ -1,5 +1,4 @@
 import org.gradle.util.GradleVersion
-
 initscript {
     def isTopLevelBuild = !gradle.parent
     if (!isTopLevelBuild) {
@@ -20,20 +19,12 @@ initscript {
     def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url')
     def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
     def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
+    def develocityInjectionPluginVersion = getInputParam('develocity-injection.plugin.version') ?: '0.0.1'
     def develocityPluginVersion = getInputParam('develocity.plugin.version')
     def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 
-    def testPluginRepository = getInputParam('develocity.test.plugin-repository') ?: '../build/local-repo'
-    def testPluginVersion = getInputParam('develocity.test.plugin-version') ?: '0.0.1'
-
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-
-    repositories {
-        maven {
-            url = testPluginRepository
-        }
-    }
 
     if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
         pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
@@ -57,7 +48,7 @@ initscript {
     }
 
     dependencies {
-        classpath "com.gradle:develocity-injection-gradle-plugin:${testPluginVersion}"
+        classpath "com.gradle:develocity-injection-gradle-plugin:${develocityInjectionPluginVersion}"
 
         if (develocityPluginVersion) {
             if (atLeastGradle5) {


### PR DESCRIPTION
This change:
- Allows configuration of plugin version in the init script to be a first class citizen
- Removes the local repo injection point in the init script